### PR TITLE
Cursor capture

### DIFF
--- a/include/ScreenCapture.h
+++ b/include/ScreenCapture.h
@@ -35,6 +35,8 @@ namespace Screen_Capture {
         Point Size;
         // Name will always be lower case. It is converted to lower case internally by the library for comparisons
         char Name[128] = {0};
+
+        float Scaling = 1.0f;
     };
     struct SC_LITE_EXTERN Monitor {
         int Id = INT32_MAX;

--- a/include/ios/NSMouseCapture.h
+++ b/include/ios/NSMouseCapture.h
@@ -11,10 +11,10 @@ struct SL_MouseCur{
 extern "C" {
 #endif
     void SLScreen_Capture_InitMouseCapture();
-    struct SL_MouseCur SLScreen_Capture_GetCurrentMouseImage();
+    struct SL_MouseCur SLScreen_Capture_GetCurrentMouseImage(float scalingFactor);
 #ifdef __cplusplus
 }
 #endif
 
 
-#endif 
+#endif

--- a/include/windows/CursorHelpers.h
+++ b/include/windows/CursorHelpers.h
@@ -33,12 +33,6 @@ class CursorHelpers {
                             BITMAP colorBitmap = {0};
                             GetObject(iconInfo.hbmColor, sizeof(colorBitmap), &colorBitmap);
 
-                            BLENDFUNCTION bf;
-                            bf.SourceConstantAlpha = 255;
-                            bf.BlendOp = AC_SRC_OVER;
-                            bf.BlendFlags = 0;
-                            bf.AlphaFormat = AC_SRC_ALPHA;
-
                             HDC hDC = GetDC(NULL);
                             HDC hMemDC = CreateCompatibleDC(hDC);
 

--- a/include/windows/CursorHelpers.h
+++ b/include/windows/CursorHelpers.h
@@ -1,0 +1,64 @@
+#pragma once
+
+class CursorHelpers {
+  public:
+    static void DrawCursor(HDC aHDC, int screenOffsetX, int screenOffsetY)
+    {
+        CURSORINFO cursorInfo = {0};
+        cursorInfo.cbSize = sizeof(CURSORINFO);
+
+        if (GetCursorInfo(&cursorInfo) == TRUE) {
+            if (cursorInfo.flags == CURSOR_SHOWING) {
+
+                HICON hicon = CopyIcon(cursorInfo.hCursor);
+
+                if (hicon != NULL) {
+
+                    ICONINFO iconInfo = {0};
+
+                    if (GetIconInfo(hicon, &iconInfo)) {
+                        const int x = cursorInfo.ptScreenPos.x - iconInfo.xHotspot - screenOffsetX;
+                        const int y = cursorInfo.ptScreenPos.y - iconInfo.yHotspot - screenOffsetY;
+
+                        BITMAP maskBitmap = {0};
+                        GetObject(iconInfo.hbmMask, sizeof(maskBitmap), &maskBitmap);
+
+                        // normal "monochrome" icons e.g. i-beam appear to work fine with DrawIconEx
+                        // icons with a color mask do not seem to work correctly and we need to manually bitblt
+                        // each bitmap mask in correctly (AND the mask, and XOR the color)
+                        if (maskBitmap.bmHeight == maskBitmap.bmWidth * 2 && iconInfo.hbmColor == NULL) {
+                            DrawIconEx(aHDC, x, y, hicon, maskBitmap.bmWidth, maskBitmap.bmWidth, 0, NULL, DI_NORMAL);
+                        }
+                        else {
+                            BITMAP colorBitmap = {0};
+                            GetObject(iconInfo.hbmColor, sizeof(colorBitmap), &colorBitmap);
+
+                            BLENDFUNCTION bf;
+                            bf.SourceConstantAlpha = 255;
+                            bf.BlendOp = AC_SRC_OVER;
+                            bf.BlendFlags = 0;
+                            bf.AlphaFormat = AC_SRC_ALPHA;
+
+                            HDC hDC = GetDC(NULL);
+                            HDC hMemDC = CreateCompatibleDC(hDC);
+
+                            SelectObject(hMemDC, iconInfo.hbmMask);
+                            BitBlt(aHDC, x, y, maskBitmap.bmHeight, maskBitmap.bmWidth, hMemDC, 0, 0, SRCAND);
+
+                            SelectObject(hMemDC, iconInfo.hbmColor);
+                            BitBlt(aHDC, x, y, colorBitmap.bmHeight, colorBitmap.bmWidth, hMemDC, 0, 0, SRCINVERT);
+
+                            DeleteDC(hMemDC);
+                            ReleaseDC(NULL, hDC);
+                        }
+
+                        DeleteObject(iconInfo.hbmColor);
+                        DeleteObject(iconInfo.hbmMask);
+                    }
+
+                    DestroyIcon(hicon);
+                }
+            }
+        }
+    }
+};

--- a/include/windows/DXFrameProcessor.h
+++ b/include/windows/DXFrameProcessor.h
@@ -16,6 +16,7 @@ namespace SL {
             Microsoft::WRL::ComPtr<ID3D11Device> Device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> DeviceContext;
             Microsoft::WRL::ComPtr<ID3D11Texture2D> StagingSurf;
+            Microsoft::WRL::ComPtr<ID3D11Texture2D> CursorSurf;
 
             Microsoft::WRL::ComPtr<IDXGIOutputDuplication> OutputDuplication;
             DXGI_OUTPUT_DESC OutputDesc;

--- a/include/windows/GDIFrameProcessor.h
+++ b/include/windows/GDIFrameProcessor.h
@@ -17,8 +17,6 @@ namespace SL {
 
             std::shared_ptr<Thread_Data> Data;
 
-			void DrawCursor();
-
         public:
             void Pause() {}
             void Resume() {}

--- a/include/windows/GDIFrameProcessor.h
+++ b/include/windows/GDIFrameProcessor.h
@@ -16,6 +16,9 @@ namespace SL {
             std::unique_ptr<unsigned char[]> NewImageBuffer;
 
             std::shared_ptr<Thread_Data> Data;
+
+			void DrawCursor();
+
         public:
             void Pause() {}
             void Resume() {}

--- a/src/ios/CGFrameProcessor.cpp
+++ b/src/ios/CGFrameProcessor.cpp
@@ -1,12 +1,13 @@
 #include "CGFrameProcessor.h"
 #include "TargetConditionals.h"
 #include <ApplicationServices/ApplicationServices.h>
+#include "NSMouseCapture.h"
 #include <iostream>
 
 namespace SL {
 namespace Screen_Capture {
 
-  
+
     DUPL_RETURN CGFrameProcessor::Init(std::shared_ptr<Thread_Data> data, Window &window)
     {
         auto ret = DUPL_RETURN::DUPL_RETURN_SUCCESS;
@@ -15,21 +16,67 @@ namespace Screen_Capture {
     }
     DUPL_RETURN CGFrameProcessor::ProcessFrame(const Window &window)
     {
+        auto mouseev = CGEventCreate(NULL);
+        auto loc = CGEventGetLocation(mouseev);
+        CFRelease(mouseev);
+
+        auto mouse = SLScreen_Capture_GetCurrentMouseImage(window.Scaling);
+
+        auto mouseWidth = CGImageGetWidth(mouse.Image);
+        auto mouseHeight = CGImageGetHeight(mouse.Image);
 
         auto Ret = DUPL_RETURN_SUCCESS;
 
-        auto imageRef = CGWindowListCreateImage(CGRectNull, kCGWindowListOptionIncludingWindow, static_cast<uint32_t>(window.Handle),
-                                                kCGWindowImageBoundsIgnoreFraming);
-        if (!imageRef)
+        auto winImageRef = CGWindowListCreateImage(
+            CGRectNull,
+            kCGWindowListOptionIncludingWindow,
+            static_cast<uint32_t>(window.Handle),
+            kCGWindowImageBoundsIgnoreFraming);
+
+        if (!winImageRef)
             return DUPL_RETURN_ERROR_EXPECTED; // this happens when the monitors change.
 
-        auto width = CGImageGetWidth(imageRef);
-        auto height = CGImageGetHeight(imageRef);
+        auto width = CGImageGetWidth(winImageRef);
+        auto height = CGImageGetHeight(winImageRef);
 
         if (width != window.Size.x || height != window.Size.y) {
-            CGImageRelease(imageRef);
+            CGImageRelease(winImageRef);
             return DUPL_RETURN_ERROR_EXPECTED; // this happens when the window sizes change.
         }
+
+        auto mouse_x_adjusted = (loc.x * window.Scaling) - (window.Position.x * 2) - mouse.HotSpotx;
+        auto mouse_y_adjusted = height - ((loc.y * window.Scaling) - (window.Position.y * 2) + (mouseHeight - mouse.HotSpoty));
+
+        auto mouseBaseRect = CGRectMake(loc.x, loc.y, mouseWidth, mouseHeight);
+        auto mouseAdjustedRect = CGRectMake(mouse_x_adjusted, mouse_y_adjusted, mouseWidth, mouseHeight);
+        auto windowRect = CGRectMake(window.Position.x, window.Position.y, window.Size.x, window.Size.y);
+
+        auto winImageRefBytesPerRow = CGImageGetBytesPerRow(winImageRef);
+
+        unsigned int * imgData = (unsigned int*)malloc(height*winImageRefBytesPerRow);
+
+        // have the graphics context now,
+        CGRect bgBoundingBox = CGRectMake (0, 0, width,height);
+
+        CGContextRef context =  CGBitmapContextCreate(imgData,
+                                                  width,
+                                                  height,
+                                                  8, // 8 bits per component
+                                                  winImageRefBytesPerRow,
+                                                  CGImageGetColorSpace(winImageRef),
+                                                  CGImageGetBitmapInfo(winImageRef));
+
+        CGContextDrawImage(context,CGRectMake(0, 0, width,height),winImageRef);
+
+        // skip drawing the cursor if no intersection
+        if (CGRectIntersectsRect(windowRect, mouseBaseRect)) {
+          CGContextDrawImage(context, mouseAdjustedRect, mouse.Image);
+        }
+
+        auto imageRef = CGBitmapContextCreateImage(context);
+
+        CGContextRelease(context);
+
         auto prov = CGImageGetDataProvider(imageRef);
         if (!prov) {
             CGImageRelease(imageRef);
@@ -43,8 +90,8 @@ namespace Screen_Capture {
         auto rawdatas = CGDataProviderCopyData(prov);
         auto buf = CFDataGetBytePtr(rawdatas);
 
-		ProcessCapture(Data->WindowCaptureData, *this, window, buf, bytesperrow);
-	  
+        ProcessCapture(Data->WindowCaptureData, *this, window, buf, bytesperrow);
+
         CFRelease(rawdatas);
         CGImageRelease(imageRef);
         return Ret;

--- a/src/ios/CGFrameProcessor.cpp
+++ b/src/ios/CGFrameProcessor.cpp
@@ -44,8 +44,8 @@ namespace Screen_Capture {
             return DUPL_RETURN_ERROR_EXPECTED; // this happens when the window sizes change.
         }
 
-        auto mouse_x_adjusted = (loc.x * window.Scaling) - (window.Position.x * 2) - mouse.HotSpotx;
-        auto mouse_y_adjusted = height - ((loc.y * window.Scaling) - (window.Position.y * 2) + (mouseHeight - mouse.HotSpoty));
+        auto mouse_x_adjusted = (loc.x * window.Scaling) - (window.Position.x * window.Scaling) - mouse.HotSpotx;
+        auto mouse_y_adjusted = height - ((loc.y * window.Scaling) - (window.Position.y * window.Scaling) + (mouseHeight - mouse.HotSpoty));
 
         auto mouseBaseRect = CGRectMake(loc.x, loc.y, mouseWidth, mouseHeight);
         auto mouseAdjustedRect = CGRectMake(mouse_x_adjusted, mouse_y_adjusted, mouseWidth, mouseHeight);

--- a/src/ios/GetWindows.cpp
+++ b/src/ios/GetWindows.cpp
@@ -74,6 +74,8 @@ namespace Screen_Capture
             w.Size.x = static_cast<int>(rect.size.width * xscale);
             w.Size.y = static_cast<int>(rect.size.height* yscale);
 
+            w.Scaling = xscale; // only support a single scaling factor
+
             std::transform(std::begin(w.Name), std::end(w.Name), std::begin(w.Name), ::tolower);
             ret.push_back(w);
         }

--- a/src/ios/NSFrameProcessorm.mm
+++ b/src/ios/NSFrameProcessorm.mm
@@ -1,7 +1,7 @@
 #include "NSFrameProcessorm.h"
 #include <thread>
 #include <chrono>
- 
+
 @implementation FrameProcessor
 
 -(SL::Screen_Capture::DUPL_RETURN) Init:(SL::Screen_Capture::NSFrameProcessor*) parent second:(CMTime)interval
@@ -12,10 +12,10 @@
         self.Paused = false;
         self.nsframeprocessor = parent;
         self.avcapturesession = [[AVCaptureSession alloc] init];
-       
+
         self.avinput = [[[AVCaptureScreenInput alloc] initWithDisplayID:SL::Screen_Capture::Id(parent->SelectedMonitor)] autorelease];
         [self.avcapturesession addInput:self.avinput];
-        
+
         self.output = [[AVCaptureVideoDataOutput alloc] init];
         NSDictionary* videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInt:kCVPixelFormatType_32BGRA], (id)kCVPixelBufferPixelFormatTypeKey, nil];
 
@@ -34,13 +34,13 @@
                 r.size.width =parent->SelectedMonitor.Width;
                 [self.avinput setCropRect:r];
         }
-        
+
         [self.avinput setMinFrameDuration:interval];
-        
-        
-        self.avinput.capturesCursor = false;
+
+
+        self.avinput.capturesCursor = true;
         self.avinput.capturesMouseClicks = false;
-       
+
         [self.avcapturesession addOutput:self.output];
         [self.output setSampleBufferDelegate:self queue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)];
         [self.avcapturesession startRunning];
@@ -78,7 +78,7 @@
     self.Paused = false;
     if(self.output){
         self.output.connections[0].enabled = YES;
-    } 
+    }
 }
 
 - (void)captureOutput:(AVCaptureOutput *)captureOutput didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
@@ -103,7 +103,7 @@
 namespace SL{
     namespace Screen_Capture{
         void SetFrameInterval(FrameProcessor* f, int ms){
-            
+
         }
         struct NSFrameProcessorImpl{
             FrameProcessor* ptr=nullptr;

--- a/src/ios/NSMouseProcessor.cpp
+++ b/src/ios/NSMouseProcessor.cpp
@@ -25,7 +25,7 @@ namespace Screen_Capture {
             auto loc = CGEventGetLocation(mouseev);
             CFRelease(mouseev);
 
-            auto imageRef = SLScreen_Capture_GetCurrentMouseImage();
+            auto imageRef = SLScreen_Capture_GetCurrentMouseImage(1.0f);
 
             if (imageRef.Image == NULL)
                 return Ret;

--- a/src/windows/DXFrameProcessor.cpp
+++ b/src/windows/DXFrameProcessor.cpp
@@ -380,14 +380,17 @@ namespace Screen_Capture {
 			// setup a DC for the surface
 			Microsoft::WRL::ComPtr<IDXGISurface1> surface;
             auto hr = CursorSurf->QueryInterface(__uuidof(IDXGISurface1), reinterpret_cast<void **>(surface.GetAddressOf()));
-            HDC surfaceDC;
-            surface->GetDC(FALSE, &surfaceDC);
 
-			// draw the cursor using this DC
-            CursorHelpers::DrawCursor(surfaceDC, SelectedMonitor.OffsetX, SelectedMonitor.OffsetY);
+            if (SUCCEEDED(hr)) {
+                HDC surfaceDC;
+                surface->GetDC(FALSE, &surfaceDC);
 
-			// release
-            surface->ReleaseDC(NULL);
+    			// draw the cursor using this DC
+                CursorHelpers::DrawCursor(surfaceDC, SelectedMonitor.OffsetX, SelectedMonitor.OffsetY);
+
+    			// release
+                surface->ReleaseDC(NULL);
+            }
 
 			// copy the composed image into staging surface to be mapped out
             DeviceContext->CopyResource(StagingSurf.Get(), CursorSurf.Get());

--- a/src/windows/DXFrameProcessor.cpp
+++ b/src/windows/DXFrameProcessor.cpp
@@ -1,6 +1,6 @@
 #include "DXFrameProcessor.h"
 #include "CursorHelpers.h"
- 
+
 #include <atomic>
 #include <iostream>
 #include <memory>
@@ -326,7 +326,7 @@ namespace Screen_Capture {
         }
 
 
-		
+
 
 
 		if (!CursorSurf || !StagingSurf) {
@@ -372,7 +372,7 @@ namespace Screen_Capture {
             }
 		}
 
-        
+
         if (Width(currentmonitorinfo) == Width(SelectedMonitor) && Height(currentmonitorinfo) == Height(SelectedMonitor)) {
 			// we first copy the acquired image into our cursor surface so that we can perform GDI operations on it
             DeviceContext->CopyResource(CursorSurf.Get(), aquireddesktopimage.Get());

--- a/src/windows/DXFrameProcessor.cpp
+++ b/src/windows/DXFrameProcessor.cpp
@@ -1,4 +1,6 @@
 #include "DXFrameProcessor.h"
+#include "CursorHelpers.h"
+ 
 #include <atomic>
 #include <iostream>
 #include <memory>
@@ -55,7 +57,7 @@ namespace Screen_Capture {
     {
         HRESULT TranslatedHr;
 #if defined _DEBUG || !defined NDEBUG
-        std::wcout << "HRESULT: " << std::hex << hr << "\t" <<Str << "\t" << Title << std::endl;
+        std::wcout << "HRESULT: " << std::hex << hr << "\t" << Str << "\t" << Title << std::endl;
 #endif
         // On an error check if the DX device is lost
         if (Device) {
@@ -244,6 +246,7 @@ namespace Screen_Capture {
         HRESULT AcquireNextFrame(UINT TimeoutInMilliseconds, DXGI_OUTDUPL_FRAME_INFO *pFrameInfo, IDXGIResource **ppDesktopResource)
         {
             auto hr = _DuplLock->AcquireNextFrame(TimeoutInMilliseconds, pFrameInfo, ppDesktopResource);
+
             TryRelease();
             AquiredLock = SUCCEEDED(hr);
             return hr;
@@ -299,7 +302,7 @@ namespace Screen_Capture {
 
     DUPL_RETURN DXFrameProcessor::ProcessFrame(const Monitor &currentmonitorinfo)
     {
-         Microsoft::WRL::ComPtr<IDXGIResource> DesktopResource;
+        Microsoft::WRL::ComPtr<IDXGIResource> DesktopResource;
         DXGI_OUTDUPL_FRAME_INFO FrameInfo = {0};
         AquireFrameRAII frame(OutputDuplication.Get());
 
@@ -311,9 +314,10 @@ namespace Screen_Capture {
         else if (FAILED(hr)) {
             return ProcessFailure(Device.Get(), L"Failed to acquire next frame in DUPLICATIONMANAGER", L"Error", hr, FrameInfoExpectedErrors);
         }
-        if (FrameInfo.AccumulatedFrames == 0) { 
+        if (FrameInfo.AccumulatedFrames == 0) {
             return DUPL_RETURN_SUCCESS;
         }
+
         Microsoft::WRL::ComPtr<ID3D11Texture2D> aquireddesktopimage;
         // QI for IDXGIResource
         hr = DesktopResource.Get()->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void **>(aquireddesktopimage.GetAddressOf()));
@@ -321,26 +325,72 @@ namespace Screen_Capture {
             return ProcessFailure(nullptr, L"Failed to QI for ID3D11Texture2D from acquired IDXGIResource in DUPLICATIONMANAGER", L"Error", hr);
         }
 
-        if (!StagingSurf) {
+
+		
+
+
+		if (!CursorSurf || !StagingSurf) {
             D3D11_TEXTURE2D_DESC ThisDesc = {0};
             aquireddesktopimage->GetDesc(&ThisDesc);
-            D3D11_TEXTURE2D_DESC StagingDesc;
-            StagingDesc = ThisDesc;
-            StagingDesc.BindFlags = 0;
-            StagingDesc.Usage = D3D11_USAGE_STAGING;
-            StagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
-            StagingDesc.MiscFlags = 0;
-            StagingDesc.Height = Height(SelectedMonitor);
-            StagingDesc.Width = Width(SelectedMonitor);
 
-            hr = Device->CreateTexture2D(&StagingDesc, nullptr, StagingSurf.GetAddressOf());
-            if (FAILED(hr)) {
-                return ProcessFailure(Device.Get(), L"Failed to create staging texture for move rects", L"Error", hr,
-                                      SystemTransitionsExpectedErrors);
+			if (!CursorSurf) {
+                D3D11_TEXTURE2D_DESC CursorDesc;
+                CursorDesc = ThisDesc;
+                CursorDesc.ArraySize = 1;
+                CursorDesc.BindFlags = D3D11_BIND_FLAG::D3D11_BIND_RENDER_TARGET;
+                CursorDesc.MiscFlags = D3D11_RESOURCE_MISC_GDI_COMPATIBLE;
+                CursorDesc.SampleDesc.Count = 1;
+                CursorDesc.SampleDesc.Quality = 0;
+                CursorDesc.MipLevels = 1;
+                CursorDesc.CPUAccessFlags = 0;
+                CursorDesc.Usage = D3D11_USAGE_DEFAULT;
+                CursorDesc.Height = Height(SelectedMonitor);
+                CursorDesc.Width = Width(SelectedMonitor);
+
+                hr = Device->CreateTexture2D(&CursorDesc, nullptr, CursorSurf.GetAddressOf());
+                if (FAILED(hr)) {
+                    return ProcessFailure(Device.Get(), L"Failed to create cursor texture for mouse pointer GDI operations", L"Error", hr,
+                                          SystemTransitionsExpectedErrors);
+                }
+			}
+
+			if (!StagingSurf) {
+                D3D11_TEXTURE2D_DESC StagingDesc;
+                StagingDesc = ThisDesc;
+                StagingDesc.BindFlags = 0;
+                StagingDesc.Usage = D3D11_USAGE_STAGING;
+                StagingDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE;
+                StagingDesc.MiscFlags = 0;
+                StagingDesc.Height = Height(SelectedMonitor);
+                StagingDesc.Width = Width(SelectedMonitor);
+
+                hr = Device->CreateTexture2D(&StagingDesc, nullptr, StagingSurf.GetAddressOf());
+                if (FAILED(hr)) {
+                    return ProcessFailure(Device.Get(), L"Failed to create staging texture for move rects", L"Error", hr,
+                                            SystemTransitionsExpectedErrors);
+                }
             }
-        }
+		}
+
+        
         if (Width(currentmonitorinfo) == Width(SelectedMonitor) && Height(currentmonitorinfo) == Height(SelectedMonitor)) {
-            DeviceContext->CopyResource(StagingSurf.Get(), aquireddesktopimage.Get());
+			// we first copy the acquired image into our cursor surface so that we can perform GDI operations on it
+            DeviceContext->CopyResource(CursorSurf.Get(), aquireddesktopimage.Get());
+
+			// setup a DC for the surface
+			Microsoft::WRL::ComPtr<IDXGISurface1> surface;
+            auto hr = CursorSurf->QueryInterface(__uuidof(IDXGISurface1), reinterpret_cast<void **>(surface.GetAddressOf()));
+            HDC surfaceDC;
+            surface->GetDC(FALSE, &surfaceDC);
+
+			// draw the cursor using this DC
+            CursorHelpers::DrawCursor(surfaceDC, SelectedMonitor.OffsetX, SelectedMonitor.OffsetY);
+
+			// release
+            surface->ReleaseDC(NULL);
+
+			// copy the composed image into staging surface to be mapped out
+            DeviceContext->CopyResource(StagingSurf.Get(), CursorSurf.Get());
         }
         else {
             D3D11_BOX sourceRegion;
@@ -361,11 +411,12 @@ namespace Screen_Capture {
             return ProcessFailure(Device.Get(),
                                   L"DrawSurface_GetPixelColor: Could not read the pixel color because the mapped subresource returned NULL", L"Error",
                                   hr, SystemTransitionsExpectedErrors);
-        } 
-        auto startsrc = reinterpret_cast<unsigned char *>(MappingDesc.pData); 
+        }
+        auto startsrc = reinterpret_cast<unsigned char *>(MappingDesc.pData);
         ProcessCapture(Data->ScreenCaptureData, *this, SelectedMonitor, startsrc, MappingDesc.RowPitch);
         return DUPL_RETURN_SUCCESS;
     }
+
 } // namespace Screen_Capture
 } // namespace SL
 

--- a/src/windows/GDIFrameProcessor.cpp
+++ b/src/windows/GDIFrameProcessor.cpp
@@ -1,5 +1,6 @@
 #include "GDIFrameProcessor.h"
 #include <Dwmapi.h>
+#include <iostream>
 
 namespace SL {
 namespace Screen_Capture {
@@ -35,6 +36,19 @@ namespace Screen_Capture {
 
         CaptureBMP.Bitmap = CreateCompatibleBitmap(MonitorDC.DC, selectedwindow.Size.x, selectedwindow.Size.y);
 
+		// identify the corresponding monitor so we can correctly offset the cursor
+		auto monitors = GetMonitors();
+		HMONITOR m = MonitorFromWindow(SelectedWindow, MONITOR_DEFAULTTOPRIMARY);
+        MONITORINFOEX minfo = {0};
+        minfo.cbSize = sizeof(MONITORINFOEX);
+        GetMonitorInfo(m, &minfo);
+
+		for (auto mit = monitors.begin(); mit != monitors.end(); mit++) {
+            if (strcmp(mit->Name, minfo.szDevice) == 0) {
+              SelectedMonitor = *mit;
+			}
+		}
+
         if (!MonitorDC.DC || !CaptureDC.DC || !CaptureBMP.Bitmap) {
             return DUPL_RETURN::DUPL_RETURN_ERROR_EXPECTED;
         }
@@ -61,7 +75,8 @@ namespace Screen_Capture {
             return DUPL_RETURN::DUPL_RETURN_ERROR_EXPECTED; // likely a permission issue
         }
         else {
-
+            DrawCursor();
+			
             BITMAPINFOHEADER bi;
             memset(&bi, 0, sizeof(bi));
 
@@ -72,20 +87,21 @@ namespace Screen_Capture {
             bi.biPlanes = 1;
             bi.biBitCount = sizeof(ImageBGRA) * 8; // always 32 bits damnit!!!
             bi.biCompression = BI_RGB;
-            bi.biSizeImage = ((ret.right * bi.biBitCount + 31) / (sizeof(ImageBGRA) * 8)) * sizeof(ImageBGRA)  * ret.bottom;
+            bi.biSizeImage = ((ret.right * bi.biBitCount + 31) / (sizeof(ImageBGRA) * 8)) * sizeof(ImageBGRA) * ret.bottom;
             GetDIBits(MonitorDC.DC, CaptureBMP.Bitmap, 0, (UINT)ret.bottom, NewImageBuffer.get(), (BITMAPINFO *)&bi, DIB_RGB_COLORS);
             SelectObject(CaptureDC.DC, originalBmp);
-            ProcessCapture(Data->ScreenCaptureData, *this, currentmonitorinfo, NewImageBuffer.get(), Width(SelectedMonitor)* sizeof(ImageBGRA));
+            ProcessCapture(Data->ScreenCaptureData, *this, currentmonitorinfo, NewImageBuffer.get(), Width(SelectedMonitor) * sizeof(ImageBGRA));
         }
 
         return Ret;
     }
 
-    static bool IsChildWindowToComposite( HWND rootWindow, HWND candidate ) {
+    static bool IsChildWindowToComposite(HWND rootWindow, HWND candidate)
+    {
         if (rootWindow == candidate)
             return false;
 
-        if (!IsWindowVisible(candidate))
+        if (!IsWindowVisible(candidate)) 
             return false;
 
         LONG exStyle = GetWindowLong(candidate, GWL_EXSTYLE);
@@ -99,7 +115,7 @@ namespace Screen_Capture {
 
         // make sure it's a popup
         LONG style = GetWindowLong(candidate, GWL_STYLE);
-        if (0 == (style & WS_POPUP) ) {
+        if (0 == (style & WS_POPUP)) {
             return false;
         }
 
@@ -124,7 +140,7 @@ namespace Screen_Capture {
 
     static std::vector<HWND> CollectWindowsToComposite(HWND hRootWindow)
     {
-         DWORD topLevelPid = 0;
+        DWORD topLevelPid = 0;
         DWORD topLevelTid = GetWindowThreadProcessId(hRootWindow, &topLevelPid);
 
         std::vector<HWND> compositeWindows;
@@ -139,13 +155,13 @@ namespace Screen_Capture {
             if (hwnd == hRootWindow)
                 return FALSE;
 
-            if ( IsTopLevelWindowToComposite( hRootWindow, hwnd )) {
+            if (IsTopLevelWindowToComposite(hRootWindow, hwnd)) {
                 compositeWindows.push_back(hwnd);
             }
 
             return TRUE;
         };
-         EnumWindows([]( HWND hwnd, LPARAM callbackParam) { return (*static_cast<decltype(fnTopLevelCallback) *>((void *)callbackParam))(hwnd, 0); },
+        EnumWindows([](HWND hwnd, LPARAM callbackParam) { return (*static_cast<decltype(fnTopLevelCallback) *>((void *)callbackParam))(hwnd, 0); },
                     (LPARAM)&fnTopLevelCallback);
 
         // find all child popup windows that need compositing
@@ -158,11 +174,11 @@ namespace Screen_Capture {
 
             return TRUE;
         };
-         EnumChildWindows(
-             hRootWindow, [](HWND hwnd, LPARAM callbackParam) { return (*static_cast<decltype(fnChildCallback) *>((void *)callbackParam))(hwnd, 0); },
-            (LPARAM)&fnChildCallback);
+        EnumChildWindows(hRootWindow,
+                         [](HWND hwnd, LPARAM callbackParam) { return (*static_cast<decltype(fnChildCallback) *>((void *)callbackParam))(hwnd, 0); },
+                         (LPARAM)&fnChildCallback);
 
-         return compositeWindows;
+        return compositeWindows;
     }
 
     DUPL_RETURN GDIFrameProcessor::ProcessFrame(Window &selectedwindow)
@@ -187,29 +203,30 @@ namespace Screen_Capture {
         auto left = -windowrect.ClientBorder.left;
         auto top = -windowrect.ClientBorder.top;
 
-        BOOL result = PrintWindow((HWND)selectedwindow.Handle, CaptureDC.DC, PW_RENDERFULLCONTENT );
+        BOOL result = PrintWindow((HWND)selectedwindow.Handle, CaptureDC.DC, PW_RENDERFULLCONTENT);
 
-        if ( !result ) {
+        if (!result) {
             result = BitBlt(CaptureDC.DC, left, top, ret.right, ret.bottom, MonitorDC.DC, 0, 0, SRCCOPY | CAPTUREBLT);
         }
 
-        if ( !result ) {
+        if (!result) {
             // if the screen cannot be captured, return
             SelectObject(CaptureDC.DC, originalBmp);
             return DUPL_RETURN::DUPL_RETURN_ERROR_EXPECTED; // likely a permission issue
         }
-
-        //std::vector<HWND> childrenToComposite = CollectWindowsToComposite((HWND)selectedwindow.Handle);
+            
+        // std::vector<HWND> childrenToComposite = CollectWindowsToComposite((HWND)selectedwindow.Handle);
         //
         //// list is ordered topmost to bottommost, so we visit them in reverse order to let painter's algorithm work
-        //for ( auto child = childrenToComposite.rbegin(); child != childrenToComposite.rend(); child++ ) {
+        // for ( auto child = childrenToComposite.rbegin(); child != childrenToComposite.rend(); child++ ) {
         //    auto childRect = SL::Screen_Capture::GetWindowRect( *child );
 
         //    HDC srcDC = GetWindowDC(*child);
 
         //    // if this fails we just won't composite this window, so continue with the others to get what we can
-        //    BOOL childBlitSuccess = BitBlt(CaptureDC.DC, childRect.ClientRect.left - windowrect.ClientRect.left, childRect.ClientRect.top - windowrect.ClientRect.top,
-        //           childRect.ClientRect.right - childRect.ClientRect.left, childRect.ClientRect.bottom - childRect.ClientRect.top, 
+        //    BOOL childBlitSuccess = BitBlt(CaptureDC.DC, childRect.ClientRect.left - windowrect.ClientRect.left, childRect.ClientRect.top -
+        //    windowrect.ClientRect.top,
+        //           childRect.ClientRect.right - childRect.ClientRect.left, childRect.ClientRect.bottom - childRect.ClientRect.top,
         //           srcDC, 0, 0,
         //           SRCCOPY | CAPTUREBLT);
         //    if ( !childBlitSuccess ) {
@@ -219,20 +236,75 @@ namespace Screen_Capture {
         //    ReleaseDC(*child, srcDC);
         //}
 
+		DrawCursor();
+
         BITMAPINFOHEADER bi;
-        memset(&bi, 0, sizeof(bi)); 
-        bi.biSize = sizeof(BITMAPINFOHEADER); 
+        memset(&bi, 0, sizeof(bi));
+        bi.biSize = sizeof(BITMAPINFOHEADER);
         bi.biWidth = Width(ret);
         bi.biHeight = -Height(ret);
         bi.biPlanes = 1;
         bi.biBitCount = sizeof(ImageBGRA) * 8; // always 32 bits damnit!!!
         bi.biCompression = BI_RGB;
-        bi.biSizeImage = ((Width(ret) * bi.biBitCount + 31) / (sizeof(ImageBGRA) * 8)) * sizeof(ImageBGRA)  * Height(ret);
+        bi.biSizeImage = ((Width(ret) * bi.biBitCount + 31) / (sizeof(ImageBGRA) * 8)) * sizeof(ImageBGRA) * Height(ret);
         GetDIBits(MonitorDC.DC, CaptureBMP.Bitmap, 0, (UINT)Height(ret), NewImageBuffer.get(), (BITMAPINFO *)&bi, DIB_RGB_COLORS);
         SelectObject(CaptureDC.DC, originalBmp);
-        ProcessCapture(Data->WindowCaptureData, *this, selectedwindow, NewImageBuffer.get(), Width(selectedwindow)* sizeof(ImageBGRA));
+        ProcessCapture(Data->WindowCaptureData, *this, selectedwindow, NewImageBuffer.get(), Width(selectedwindow) * sizeof(ImageBGRA));
 
         return Ret;
     }
+
+	void GDIFrameProcessor::DrawCursor() {
+        CURSORINFO cursorInfo = {0};
+        cursorInfo.cbSize = sizeof(CURSORINFO);
+
+        if (GetCursorInfo(&cursorInfo) == TRUE) {
+            if (cursorInfo.flags == CURSOR_SHOWING) {
+
+                HICON hicon = CopyIcon(cursorInfo.hCursor);
+
+                if (hicon != NULL) {
+
+                    ICONINFO iconInfo = {0};
+
+                    if (GetIconInfo(hicon, &iconInfo)) {
+                        const int x = cursorInfo.ptScreenPos.x - iconInfo.xHotspot - SelectedMonitor.OffsetX;
+                        const int y = cursorInfo.ptScreenPos.y - iconInfo.yHotspot - SelectedMonitor.OffsetY;
+
+                        BITMAP maskBitmap = {0};
+                        GetObject(iconInfo.hbmMask, sizeof(maskBitmap), &maskBitmap);
+
+                        // normal "monochrome" icons e.g. i-beam appear to work fine with DrawIconEx
+                        // icons with a color mask do not seem to work correctly and we need to manually bitblt
+                        // each bitmap mask in correctly (AND the mask, and XOR the color)
+                        if (maskBitmap.bmHeight == maskBitmap.bmWidth * 2 && iconInfo.hbmColor == NULL) {
+                            DrawIconEx(CaptureDC.DC, x, y, hicon, maskBitmap.bmWidth, maskBitmap.bmWidth, 0, NULL, DI_NORMAL);
+                        }
+                        else {
+                            BITMAP colorBitmap = {0};
+                            GetObject(iconInfo.hbmColor, sizeof(colorBitmap), &colorBitmap);
+
+                            HDC hDC = GetDC(NULL);
+                            HDC hMemDC = CreateCompatibleDC(hDC);
+
+                            SelectObject(hMemDC, iconInfo.hbmMask);
+                            BitBlt(CaptureDC.DC, x, y, maskBitmap.bmHeight, maskBitmap.bmWidth, hMemDC, 0, 0, SRCAND);
+
+                            SelectObject(hMemDC, iconInfo.hbmColor);
+                            BitBlt(CaptureDC.DC, x, y, colorBitmap.bmHeight, colorBitmap.bmWidth, hMemDC, 0, 0, SRCINVERT);
+
+                            DeleteDC(hMemDC);
+                            ReleaseDC(NULL, hDC);
+                        }
+
+						DeleteObject(iconInfo.hbmColor);
+                        DeleteObject(iconInfo.hbmMask);
+                    }
+
+                    DestroyIcon(hicon);
+                }
+            }
+        }
+	}
 } // namespace Screen_Capture
 } // namespace SL

--- a/src/windows/GDIFrameProcessor.cpp
+++ b/src/windows/GDIFrameProcessor.cpp
@@ -1,6 +1,6 @@
 #include "GDIFrameProcessor.h"
 #include "CursorHelpers.h"
-     
+
 #include <Dwmapi.h>
 #include <iostream>
 
@@ -39,6 +39,7 @@ namespace Screen_Capture {
         CaptureBMP.Bitmap = CreateCompatibleBitmap(MonitorDC.DC, selectedwindow.Size.x, selectedwindow.Size.y);
 
 		// identify the corresponding monitor so we can correctly offset the cursor
+
 		auto monitors = GetMonitors();
 		HMONITOR m = MonitorFromWindow(SelectedWindow, MONITOR_DEFAULTTOPRIMARY);
         MONITORINFOEX minfo = {0};
@@ -78,7 +79,7 @@ namespace Screen_Capture {
         }
         else {
             CursorHelpers::DrawCursor(CaptureDC.DC, SelectedMonitor.OffsetX, SelectedMonitor.OffsetY);
-			
+
             BITMAPINFOHEADER bi;
             memset(&bi, 0, sizeof(bi));
 
@@ -103,7 +104,7 @@ namespace Screen_Capture {
         if (rootWindow == candidate)
             return false;
 
-        if (!IsWindowVisible(candidate)) 
+        if (!IsWindowVisible(candidate))
             return false;
 
         LONG exStyle = GetWindowLong(candidate, GWL_EXSTYLE);
@@ -216,7 +217,7 @@ namespace Screen_Capture {
             SelectObject(CaptureDC.DC, originalBmp);
             return DUPL_RETURN::DUPL_RETURN_ERROR_EXPECTED; // likely a permission issue
         }
-            
+
         // std::vector<HWND> childrenToComposite = CollectWindowsToComposite((HWND)selectedwindow.Handle);
         //
         //// list is ordered topmost to bottommost, so we visit them in reverse order to let painter's algorithm work


### PR DESCRIPTION
This enables capturing + drawing the mouse capture in OSX when using NSFrameProcessor (full screen capture) and CGFrameProcessor(window capture), on Windows when using either GDIFrameProcessor (window capture) or DXFrameProcessor (full screen).

It's crazy it takes this much effort just to capture the damn cursor.

Some relevant resources I utilized: 
https://github.com/smasherprog/screen_capture_lite/issues/75
https://stackoverflow.com/questions/918990/c-sharp-capturing-the-mouse-cursor-image
https://www.codeproject.com/Tips/1116253/Desktop-Screen-Capture-on-Windows-via-Windows-Desk